### PR TITLE
browserslist设置项更新

### DIFF
--- a/config/postcss.config.js
+++ b/config/postcss.config.js
@@ -3,6 +3,6 @@
 
 module.exports = {
   plugins: [
-    require('autoprefixer')({ browsers: ['iOS >= 7', 'Android >= 4.0'] })
+    require('autoprefixer')({ overrideBrowserslist: ['iOS >= 7', 'Android >= 4.0'] })
   ]
 };


### PR DESCRIPTION
解决大量警告问题

```
Replace Autoprefixer browsers option to Browserslist config.
  Use browserslist key in package.json or .browserslistrc file.

  Using browsers option cause some error. Browserslist config
  can be used for Babel, Autoprefixer, postcss-normalize and other tools.

  If you really need to use option, rename it to overrideBrowserslist.

  Learn more at:
  https://github.com/browserslist/browserslist#readme
  https://twitter.com/browserslist
```